### PR TITLE
[BUGFIX] Use correct configuration for settingsId

### DIFF
--- a/Configuration/TypoScript/Static/setup.typoscript
+++ b/Configuration/TypoScript/Static/setup.typoscript
@@ -1,5 +1,4 @@
 plugin.tx_usercentrics {
-    id = {$plugin.tx_usercentrics.settingsId}
+    settingsId = {$plugin.tx_usercentrics.settingsId}
     language = {$plugin.tx_usercentrics.language}
 }
-


### PR DESCRIPTION
The TypoScript setup used a wrong configuration to set the Usercentrics
settings ID, which triggers an exception when using TypoScript constants
only.

This change fixes the wrong configuration name to be `settingsId`.

Fixes: #19