### PR TITLE
[BUGFIX] Unescape src before hand it over to the asset collector

### DIFF
--- a/Classes/ViewHelpers/ScriptViewHelper.php
+++ b/Classes/ViewHelpers/ScriptViewHelper.php
@@ -47,7 +47,7 @@ class ScriptViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Asset\ScriptViewHelp
             'priority' => $this->arguments['priority']
         ];
         if ($src !== null) {
-            $this->assetCollector->addJavaScript($identifier, $src, $attributes, $options);
+            $this->assetCollector->addJavaScript($identifier, html_entity_decode($src), $attributes, $options);
         } else {
             $content = (string)$this->renderChildren();
             if ($content !== '') {


### PR DESCRIPTION
Attributes with parameters like &callback=foo will be double encoded.
This patch prevents this issue, by unescaping the src value.

Releases: develop, 10, 9.5