### PR TITLE
[!!!][TASK] Provide TYPO3 v12 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,40 +9,43 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        typo3: [^10.4, dev-master]
-        php: ['7.4']
+        typo3: [^11.5, ^12.4]
+        php: ['8.1', '8.2']
         include:
-          - typo3: ^10.4
+          - typo3: ^11.5
             php: '7.4'
-          - typo3: ^10.4
-            php: '7.3'
-          - typo3: ^10.4
-            php: '7.2'
-          - typo3: dev-master
+          - typo3: ^11.5
             php: '8.0'
-          - typo3: dev-master
-            php: '7.4'
+          - typo3: ^11.5
+            php: '8.1'
+          - typo3: ^11.5
+            php: '8.2'
+          - typo3: ^12.4
+            php: '8.1'
+          - typo3: ^12.4
+            php: '8.2'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup PHP ${{ matrix.php }}
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
 
-    - name: Update Composer
-      run: |
-        sudo composer self-update
-        composer --version
-
     - name: Validate composer.json and composer.lock
       run: composer validate
 
     - name: Install dependencies
       run: |
-        composer require typo3/cms-core:${{ matrix.typo3 }} --no-progress
+        composer require typo3/cms-core:${{ matrix.typo3 }} --no-progress --ansi
         git checkout composer.json
+
+    - name: Install dev tools
+      run: |
+        for tool in `ls -1 Build/tools`; do
+          composer install --working-dir="Build/tools/$tool" --no-progress --ansi
+        done
 
     - name: CGL
       run: composer t3g:cgl

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
   publish:
     name: Publish new version to TER
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
           extensions: intl, mbstring, json, zip, curl
 
       - name: Install tailor

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ var/
 config/
 
 # CGL Fixer
-.php_cs.cache
+.php-cs-fixer.cache
+.phplint.cache

--- a/.php_cs-fixer.dist.php
+++ b/.php_cs-fixer.dist.php
@@ -40,7 +40,7 @@ return (new PhpCsFixer\Config())
             ],
         ],
         'no_leading_import_slash' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
         'concat_space' => ['spacing' => 'one'],

--- a/.phplint.yml
+++ b/.phplint.yml
@@ -5,3 +5,4 @@ extensions:
     - php
 exclude:
     - .build
+    - Build

--- a/Build/tools/php-cs-fixer/composer.json
+++ b/Build/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3.20"
+    }
+}

--- a/Build/tools/phplint/composer.json
+++ b/Build/tools/phplint/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "overtrue/phplint": "^3.3 || ^4.5"
+    }
+}

--- a/Classes/ViewHelpers/ScriptViewHelper.php
+++ b/Classes/ViewHelpers/ScriptViewHelper.php
@@ -10,7 +10,10 @@ declare(strict_types = 1);
 
 namespace T3G\AgencyPack\Usercentrics\ViewHelpers;
 
+use TYPO3\CMS\Core\Page\AssetCollector;
 use TYPO3\CMS\Core\Utility\StringUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
 /**
  * Usercentrics Viewhelper
@@ -25,12 +28,71 @@ use TYPO3\CMS\Core\Utility\StringUtility;
  *       alert('hello world');
  *    </usercentrics:script>
  */
-class ScriptViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Asset\ScriptViewHelper
+class ScriptViewHelper extends AbstractTagBasedViewHelper
 {
+    /**
+     * This VH does not produce direct output, thus does not need to be wrapped in an escaping node
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * Rendered children string is passed as JavaScript code,
+     * there is no point in HTML encoding anything from that.
+     *
+     * @var bool
+     */
+    protected $escapeChildren = false;
+
+    protected AssetCollector $assetCollector;
+
+    public function injectAssetCollector(AssetCollector $assetCollector): void
+    {
+        $this->assetCollector = $assetCollector;
+    }
+
+    public function initialize(): void
+    {
+        // Add a tag builder, that does not html encode values, because rendering with encoding happens in AssetRenderer
+        $this->setTagBuilder(
+            new class() extends TagBuilder {
+                public function addAttribute($attributeName, $attributeValue, $escapeSpecialCharacters = false): void
+                {
+                    parent::addAttribute($attributeName, $attributeValue, false);
+                }
+            }
+        );
+        parent::initialize();
+    }
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();
-        $this->registerArgument('dataServiceProcessor', 'string', 'the data processing service name as configured in Usercentrics', true);
+        $this->registerUniversalTagAttributes();
+        $this->registerTagAttribute('async', 'bool', 'Define that the script will be fetched in parallel to parsing and evaluation.', false);
+        $this->registerTagAttribute('crossorigin', 'string', 'Define how to handle crossorigin requests.', false);
+        $this->registerTagAttribute('defer', 'bool', 'Define that the script is meant to be executed after the document has been parsed.', false);
+        $this->registerTagAttribute('integrity', 'string', 'Define base64-encoded cryptographic hash of the resource that allows browsers to verify what they fetch.', false);
+        $this->registerTagAttribute('nomodule', 'bool', 'Define that the script should not be executed in browsers that support ES2015 modules.', false);
+        $this->registerTagAttribute('nonce', 'string', 'Define a cryptographic nonce (number used once) used to whitelist inline styles in a style-src Content-Security-Policy.', false);
+        $this->registerTagAttribute('referrerpolicy', 'string', 'Define which referrer is sent when fetching the resource.', false);
+        $this->registerTagAttribute('src', 'string', 'Define the URI of the external resource.', false);
+        $this->registerTagAttribute('type', 'string', 'Define the MIME type (usually \'text/javascript\').', false);
+        $this->registerArgument('useNonce', 'bool', 'Whether to use the global nonce value', false, false);
+        $this->registerArgument(
+            'identifier',
+            'string',
+            'Use this identifier within templates to only inject your JS once, even though it is added multiple times.',
+            true
+        );
+        $this->registerArgument(
+            'priority',
+            'boolean',
+            'Define whether the JavaScript should be put in the <head> tag above-the-fold or somewhere in the body part.',
+            false,
+            false
+        );
         $this->registerArgument('dataProcessingService', 'string', 'the data processing service name as configured in Usercentrics', true);
     }
 
@@ -59,13 +121,6 @@ class ScriptViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Asset\ScriptViewHelp
 
     protected function getDataProcessingService(): string
     {
-        if (isset($this->arguments['dataServiceProcessor'])) {
-            trigger_error(
-                'The argument "dataServiceProcessor" of ' . self::class . ' has been marked as deprecated. Use dataProcessingService instead.',
-                E_USER_DEPRECATED
-            );
-            return $this->arguments['dataServiceProcessor'];
-        }
         return $this->arguments['dataProcessingService'];
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,3 +7,8 @@ services:
   T3G\AgencyPack\Usercentrics\:
     resource: '../Classes/*'
 
+  T3G\AgencyPack\Usercentrics\EventListener\AssetRenderer\UsercentricsLibrary:
+    tags:
+      - name: event.listener
+        identifier: 'usercentrics/UsercentricsLibrary'
+        event: TYPO3\CMS\Core\Page\Event\BeforeJavaScriptsRenderingEvent

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -7,11 +7,13 @@
  * LICENSE file that was distributed with this source code.
  */
 
-if (!defined('TYPO3_MODE')) {
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+if (!defined('TYPO3')) {
     die('Access denied.');
 }
 
 call_user_func(static function () {
     // Add static template
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('usercentrics', 'Configuration/TypoScript/Static/', 'Usercentrics Integration');
+    ExtensionManagementUtility::addStaticFile('usercentrics', 'Configuration/TypoScript/Static/', 'Usercentrics Integration');
 });

--- a/composer.json
+++ b/composer.json
@@ -32,21 +32,25 @@
         "bin-dir": ".build/bin",
         "discard-changes": true,
         "optimize-autoloader": true,
-        "vendor-dir": ".build/vendor"
+        "vendor-dir": ".build/vendor",
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
+        }
     },
     "extra": {
         "typo3/cms": {
             "extension-key": "usercentrics",
-            "web-dir": ".build/web",
+            "web-dir": ".build/public",
             "app-dir": ".build"
         },
         "branch-alias": {
-            "dev-develop": "11.0.x-dev"
+            "dev-develop": "12.0.x-dev"
         }
     },
     "scripts": {
         "t3g:test:php:lint": [
-            "phplint"
+            "Build/tools/phplint/vendor/bin/phplint"
         ],
         "t3g:test:php:unit": [
             "phpunit -c Build/UnitTests.xml"
@@ -56,26 +60,24 @@
             "@t3g:test:php:unit"
         ],
         "t3g:cgl": [
-            "php-cs-fixer fix --config=.php_cs-fixer.dist.php -v --dry-run"
+            "Build/tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config=.php_cs-fixer.dist.php -v --dry-run"
         ],
         "t3g:cgl:fix": [
-            "php-cs-fixer fix --config=.php_cs-fixer.dist.php"
+            "Build/tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config=.php_cs-fixer.dist.php"
         ],
         "post-autoload-dump": [
-            "mkdir -p .build/web/typo3conf/ext/",
-            "[ -L .build/web/typo3conf/ext/usercentrics ] || ln -snvf ../../../../. .build/web/typo3conf/ext/usercentrics"
+            "[ -d .build/public/_assets ] || mkdir -p .build/public/typo3conf/ext/",
+            "[ -d .build/public/_assets ] || [ -L .build/public/typo3conf/ext/usercentrics ] || ln -snvf ../../../../. .build/public/typo3conf/ext/usercentrics"
         ]
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "typo3/cms-core": "^10.4 || 11.*.*@dev"
+        "typo3/cms-core": "^11.4 || 12.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^v2.19",
         "roave/security-advisories": "dev-latest",
-        "typo3/testing-framework": "^4.9 || ^5.0 || ^6.3",
-        "bk2k/extension-helper": "^1.0",
-        "overtrue/phplint": "^3.0"
+        "typo3/testing-framework": "^7.0 || ^8.0",
+        "phpunit/phpunit": "^8.4 || ^9.0"
     }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,10 +15,10 @@ $EM_CONF[$_EXTKEY] = [
     'clearCacheOnLoad' => 0,
     'author' => 'TYPO3 GmbH',
     'author_email' => 'info@typo3.com',
-    'version' => '11.0.0',
+    'version' => '12.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.0.0-11.4.99',
+            'typo3' => '11.0.0-12.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,14 +7,11 @@
  * LICENSE file that was distributed with this source code.
  */
 
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
     die('Access denied.');
 }
 
 call_user_func(static function () {
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][\T3G\AgencyPack\Usercentrics\Hooks\PageRendererPreProcess::class]
-        = \T3G\AgencyPack\Usercentrics\Hooks\PageRendererPreProcess::class . '->addLibrary';
-
     // Register "usercentrics" as global fluid namespace
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['usercentrics'][] = 'T3G\\AgencyPack\\Usercentrics\\ViewHelpers';
 });


### PR DESCRIPTION
The extension is declared compatible to TYPO3 v12. In the same run, support for TYPO3 v10 has been dropped.

Also, the deprecated configuration `dataServiceProcessor` has been removed.